### PR TITLE
Remove debug builds from ripgrep and add extra flags to release profile

### DIFF
--- a/build/install.sh
+++ b/build/install.sh
@@ -83,6 +83,9 @@ configure_cargo() {
         cat >> .cargo/config <<EOF
 [target.$TARGET]
 linker = "${gcc}"
+EOF
+
+        cat >> Cargo.toml <<EOF
 [profile.release]
 debug = false
 strip = true

--- a/build/install.sh
+++ b/build/install.sh
@@ -82,8 +82,9 @@ configure_cargo() {
         mkdir -p .cargo
         cat >> .cargo/config <<EOF
 [target.$TARGET]
-debug = false
 linker = "${gcc}"
+[profile.release]
+debug = false
 EOF
     fi
 }

--- a/build/install.sh
+++ b/build/install.sh
@@ -80,17 +80,19 @@ configure_cargo() {
 
         # tell cargo which linker to use for cross compilation
         mkdir -p .cargo
+        
         cat >> .cargo/config <<EOF
 [target.$TARGET]
 linker = "${gcc}"
 EOF
     fi
-        cat >> Cargo.toml <<EOF
+    cat >> .cargo/config <<EOF
+    
 [profile.release]
 debug = false
 strip = true
 EOF
-cat Cargo.toml
+cat .cargo/config
 }
 
 main() {

--- a/build/install.sh
+++ b/build/install.sh
@@ -85,6 +85,7 @@ configure_cargo() {
 linker = "${gcc}"
 [profile.release]
 debug = false
+strip = true
 EOF
     fi
 }

--- a/build/install.sh
+++ b/build/install.sh
@@ -89,11 +89,11 @@ EOF
 
     cat >> .cargo/config <<EOF
 
-[profile.release]
-debug = false
-strip = true
-lto = true
-codegen-units = 1
+[profile.release] # release flags https://doc.rust-lang.org/cargo/reference/profiles.html#release
+debug = false # don't ship with debug builds 
+strip = true # removes debug symbols
+lto = true # enables link time optimization
+codegen-units = 1 # makes it link in a single progress, where it normally runs in multiple independent workers in parallel. Might make compilation a little slower
 EOF
 }
 

--- a/build/install.sh
+++ b/build/install.sh
@@ -90,6 +90,7 @@ EOF
 debug = false
 strip = true
 EOF
+cat Cargo.toml
 }
 
 main() {

--- a/build/install.sh
+++ b/build/install.sh
@@ -84,13 +84,12 @@ configure_cargo() {
 [target.$TARGET]
 linker = "${gcc}"
 EOF
-
+    fi
         cat >> Cargo.toml <<EOF
 [profile.release]
 debug = false
 strip = true
 EOF
-    fi
 }
 
 main() {

--- a/build/install.sh
+++ b/build/install.sh
@@ -71,7 +71,9 @@ install_linux_dependencies() {
 }
 
 configure_cargo() {
+    mkdir -p .cargo
     local prefix=$(gcc_prefix)
+
     if [ -n "${prefix}" ]; then
         local gcc="${prefix}gcc"
 
@@ -79,20 +81,18 @@ configure_cargo() {
         "${gcc}" -v
 
         # tell cargo which linker to use for cross compilation
-        mkdir -p .cargo
-        
         cat >> .cargo/config <<EOF
 [target.$TARGET]
 linker = "${gcc}"
 EOF
     fi
-    cat >> .cargo/config <<EOF
     
+    cat >> .cargo/config <<EOF
+
 [profile.release]
 debug = false
 strip = true
 EOF
-cat .cargo/config
 }
 
 main() {

--- a/build/install.sh
+++ b/build/install.sh
@@ -82,6 +82,7 @@ configure_cargo() {
         mkdir -p .cargo
         cat >> .cargo/config <<EOF
 [target.$TARGET]
+debug = false
 linker = "${gcc}"
 EOF
     fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -86,12 +86,14 @@ configure_cargo() {
 linker = "${gcc}"
 EOF
     fi
-    
+
     cat >> .cargo/config <<EOF
 
 [profile.release]
 debug = false
 strip = true
+lto = true
+codegen-units = 1
 EOF
 }
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: 'stable'
+  rust_version: '1.56.0'
   repo: ''
   tag: ''
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.57.0'
+  rust_version: '1.58.0'
   repo: ''
   tag: ''
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.58.0'
+  rust_version: '1.57.0'
   repo: ''
   tag: ''
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.57.0'
+  rust_version: '1.59.0'
   repo: ''
   tag: ''
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -29,10 +29,10 @@ steps:
   env:
     TARGET: ${{ parameters.target }}
     OUT_DIR: $(Build.ArtifactStagingDirectory)
-  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+  condition: succeeded()
 - task: PublishPipelineArtifact@0
   displayName: 'Publish Pipeline Artifact'
   inputs:
     artifactName: $(Name)
     targetPath: $(Build.ArtifactStagingDirectory)/$(Name)
-  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+  condition: succeeded()

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.59.0'
+  rust_version: '1.58.0'
   repo: ''
   tag: ''
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.56.0'
+  rust_version: '1.57.0'
   repo: ''
   tag: ''
 

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.58.0'
+  rust_version: '1.67.0'
   repo: ''
   tag: ''
 

--- a/build/main.yml
+++ b/build/main.yml
@@ -51,21 +51,21 @@ jobs:
         rust_version: nightly
 - job: win_64
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: windows-2022
   steps:
     - template: windows.yml
       parameters:
         target: x86_64-pc-windows-msvc
 - job: win_32
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: windows-2022
   steps:
     - template: windows.yml
       parameters:
         target: i686-pc-windows-msvc
 - job: win_arm64
   pool:
-    vmImage: VS2017-Win2016
+    vmImage: windows-2022
   steps:
     - template: windows.yml
       parameters:

--- a/build/package.sh
+++ b/build/package.sh
@@ -15,8 +15,10 @@ mk_tarball() {
     # When cross-compiling, use the right `strip` tool on the binary.
     local gcc_prefix="$(gcc_prefix)"
     
-    # Copy the ripgrep binary and strip it.
-    "${gcc_prefix}strip" "target/$TARGET/release/rg"
+    if [ -n "${gcc_prefix}" ]; then
+        # Copy the ripgrep binary and strip it.
+        "${gcc_prefix}strip" "target/$TARGET/release/rg"
+    fi
 
     tar czvf "$OUT_DIR/$name" -C ./target/$TARGET/release rg
     echo "##vso[task.setvariable variable=Name]$name"

--- a/build/package.sh
+++ b/build/package.sh
@@ -12,13 +12,7 @@ mk_tarball() {
     this_tag=`git tag -l --contains HEAD`
     popd
     local name="ripgrep-${this_tag}-${TARGET}.tar.gz"
-    # When cross-compiling, use the right `strip` tool on the binary.
-    local gcc_prefix="$(gcc_prefix)"
     
-    if [ -n "${gcc_prefix}" ]; then
-        # Copy the ripgrep binary and strip it.
-        "${gcc_prefix}strip" "target/$TARGET/release/rg"
-    fi
 
     tar czvf "$OUT_DIR/$name" -C ./target/$TARGET/release rg
     echo "##vso[task.setvariable variable=Name]$name"

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -149,7 +149,7 @@ is_osx() {
 
 builder() {
     if is_musl && is_aarch64_musl; then
-        cargo install cross
+        cargo install cross --version 0.2.2
         echo "cross"
     else
         echo "cargo"

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -149,7 +149,7 @@ is_osx() {
 
 builder() {
     if is_musl && is_aarch64_musl; then
-        cargo install cross --version 0.2.2
+        cargo install cross --version 0.2.1
         echo "cross"
     else
         echo "cargo"


### PR DESCRIPTION
Fixes #15
Fixes #20 

Doesn't use the latest cross version since it runs into an issue with `pcre2` that should be fixed when https://github.com/BurntSushi/rust-pcre2/pull/30 is merged upstream.

----

Made the `x86_64-unknown-linux-musl` prebuilt go from ~39.1MB to ~5.1MB.
Made the `i686-unknown-linux-musl` prebuilt go from ~29.7MB to ~4.0MB.

