### PR TITLE
change `arm-unknown-linux-gnueabihf` to musl

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,7 +11,7 @@ main() {
     CARGO="$(builder)"
 
     # Test a normal debug build.
-    if is_arm_musl || is_aarch64 || is_ppc64le; then
+    if is_aarch64 || is_ppc64le; then
         "$CARGO" build --target "$TARGET" --release --features 'pcre2'
     # pcre2 is not supported on s390x
     # https://github.com/zherczeg/sljit/issues/89

--- a/build/build.sh
+++ b/build/build.sh
@@ -11,7 +11,7 @@ main() {
     CARGO="$(builder)"
 
     # Test a normal debug build.
-    if is_arm || is_aarch64 || is_ppc64le; then
+    if is_arm_musl || is_aarch64 || is_ppc64le; then
         "$CARGO" build --target "$TARGET" --release --features 'pcre2'
     # pcre2 is not supported on s390x
     # https://github.com/zherczeg/sljit/issues/89
@@ -38,7 +38,7 @@ main() {
 
     # Apparently tests don't work on arm, s390x and ppc64le so just bail now. I guess we provide
     # ARM, ppc64le and s390x releases on a best effort basis?
-    if is_arm || is_aarch64 || is_arm64 || is_ppc64le || is_s390x; then
+    if is_arm_musl || is_aarch64 || is_arm64 || is_ppc64le || is_s390x; then
       return 0
     fi
 

--- a/build/install.sh
+++ b/build/install.sh
@@ -51,6 +51,8 @@ install_linux_dependencies() {
     sudo apt-get install -y musl-tools
 
     if is_arm_musl; then
+        sudo apt-get install gcc-arm-linux-gnueabihf
+        sudo apt-get install binutils-arm-linux-gnueabihf
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross
     fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -75,7 +75,7 @@ configure_cargo() {
         local gcc="${prefix}gcc"
 
         # information about the cross compiler
-        "${gcc}" -v
+        # "${gcc}" -v
 
         mkdir -p .cargo
 

--- a/build/install.sh
+++ b/build/install.sh
@@ -50,7 +50,7 @@ install_linux_dependencies() {
     sudo apt-get update
     sudo apt-get install -y musl-tools
 
-    if is_arm; then
+    if is_arm_musl; then
         sudo apt-get install arm-linux-musleabihf-gcc
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross

--- a/build/install.sh
+++ b/build/install.sh
@@ -51,7 +51,6 @@ install_linux_dependencies() {
     sudo apt-get install -y musl-tools
 
     if is_arm_musl; then
-        sudo apt-get install arm-linux-musleabihf-gcc
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross
     fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -53,6 +53,7 @@ install_linux_dependencies() {
     if is_arm_musl; then
         sudo apt-get install gcc-arm-linux-gnueabihf
         sudo apt-get install binutils-arm-linux-gnueabihf
+        ln -s /usr/bin/arm-linux-gnueabihf-gcc /usr/bin/arm-linux-musleabihf-gcc    
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross
     fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -77,11 +77,12 @@ configure_cargo() {
         local gcc="${prefix}gcc"
 
         # information about the cross compiler
-        # "${gcc}" -v
+        "${gcc}" -v
 
         mkdir -p .cargo
 
         # tell cargo which linker to use for cross compilation
+        
         cat >> ripgrep/.cargo/config <<EOF
 [target.$TARGET]
 linker = "${gcc}"

--- a/build/install.sh
+++ b/build/install.sh
@@ -53,7 +53,7 @@ install_linux_dependencies() {
     if is_arm_musl; then
         sudo apt-get install gcc-arm-linux-gnueabihf
         sudo apt-get install binutils-arm-linux-gnueabihf
-        ln -s /usr/bin/arm-linux-gnueabihf-gcc /usr/bin/arm-linux-musleabihf-gcc    
+        sudo ln -s /usr/bin/arm-linux-gnueabihf-gcc /usr/bin/arm-linux-musleabihf-gcc    
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross
     fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -51,8 +51,7 @@ install_linux_dependencies() {
     sudo apt-get install -y musl-tools
 
     if is_arm; then
-        sudo apt-get install gcc-arm-linux-gnueabihf
-        sudo apt-get install binutils-arm-linux-gnueabihf
+        sudo apt-get install arm-linux-musleabihf-gcc
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross
     fi

--- a/build/install.sh
+++ b/build/install.sh
@@ -82,7 +82,7 @@ configure_cargo() {
         mkdir -p .cargo
 
         # tell cargo which linker to use for cross compilation
-        cat >> .cargo/config <<EOF
+        cat >> ripgrep/.cargo/config <<EOF
 [target.$TARGET]
 linker = "${gcc}"
 EOF

--- a/build/install.sh
+++ b/build/install.sh
@@ -52,8 +52,7 @@ install_linux_dependencies() {
 
     if is_arm_musl; then
         sudo apt-get install gcc-arm-linux-gnueabihf
-        sudo apt-get install binutils-arm-linux-gnueabihf
-        sudo ln -s /usr/bin/arm-linux-gnueabihf-gcc /usr/bin/arm-linux-musleabihf-gcc    
+        sudo apt-get install binutils-arm-linux-gnueabihf 
         sudo apt-get install libc6-armhf-cross
         sudo apt-get install libc6-dev-armhf-cross
     fi

--- a/build/main.yml
+++ b/build/main.yml
@@ -1,113 +1,113 @@
 jobs:
-  - job: linux_64
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: x86_64-unknown-linux-musl
-  - job: linux_32
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: i686-unknown-linux-musl
-  - job: linux_arm
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: arm-unknown-linux-musleabihf
-  - job: linux_aarch64
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: aarch64-unknown-linux-gnu
-  - job: linux_aarch64_musl
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: aarch64-unknown-linux-musl
-  - job: macOS
-    pool:
-      vmImage: macOS-latest
-    steps:
-      - template: linux.yml
-        parameters:
-          target: x86_64-apple-darwin
-  - job: macOS_arm64
-    pool:
-      vmImage: macOS-latest
-    steps:
-      - template: linux.yml
-        parameters:
-          target: aarch64-apple-darwin
-          rust_version: nightly
-  - job: win_64
-    pool:
-      vmImage: windows-2022
-    steps:
-      - template: windows.yml
-        parameters:
-          target: x86_64-pc-windows-msvc
-  - job: win_32
-    pool:
-      vmImage: windows-2022
-    steps:
-      - template: windows.yml
-        parameters:
-          target: i686-pc-windows-msvc
-  - job: win_arm64
-    pool:
-      vmImage: windows-2022
-    steps:
-      - template: windows.yml
-        parameters:
-          target: aarch64-pc-windows-msvc
-  - job: ppc64le
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: powerpc64le-unknown-linux-gnu
-  - job: s390x
-    pool:
-      vmImage: "ubuntu-latest"
-    steps:
-      - template: linux.yml
-        parameters:
-          target: s390x-unknown-linux-gnu
-  - job: publish
-    pool:
-      vmImage: "ubuntu-latest"
-    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-    dependsOn:
-      - linux_64
-      - linux_32
-      - linux_arm
-      - linux_aarch64
-      - linux_aarch64_musl
-      - macOS
-      - macOS_arm64
-      - win_64
-      - win_32
-      - win_arm64
-      - ppc64le
-      - s390x
-    steps:
-      - template: publish.yml
+- job: linux_64
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: x86_64-unknown-linux-musl
+- job: linux_32
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: i686-unknown-linux-musl
+- job: linux_arm
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: arm-unknown-linux-musleabihf
+- job: linux_aarch64
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: aarch64-unknown-linux-gnu
+- job: linux_aarch64_musl
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: aarch64-unknown-linux-musl
+- job: macOS
+  pool:
+    vmImage: macOS-latest
+  steps:
+    - template: linux.yml
+      parameters:
+        target: x86_64-apple-darwin
+- job: macOS_arm64
+  pool:
+    vmImage: macOS-latest
+  steps:
+    - template: linux.yml
+      parameters:
+        target: aarch64-apple-darwin
+        rust_version: nightly
+- job: win_64
+  pool:
+    vmImage: windows-2022
+  steps:
+    - template: windows.yml
+      parameters:
+        target: x86_64-pc-windows-msvc
+- job: win_32
+  pool:
+    vmImage: windows-2022
+  steps:
+    - template: windows.yml
+      parameters:
+        target: i686-pc-windows-msvc
+- job: win_arm64
+  pool:
+    vmImage: windows-2022
+  steps:
+    - template: windows.yml
+      parameters:
+        target: aarch64-pc-windows-msvc
+- job: ppc64le
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: powerpc64le-unknown-linux-gnu
+- job: s390x
+  pool:
+    vmImage: 'ubuntu-latest'
+  steps:
+    - template: linux.yml
+      parameters:
+        target: s390x-unknown-linux-gnu
+- job: publish
+  pool:
+    vmImage: 'ubuntu-latest'
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+  dependsOn:
+  - linux_64
+  - linux_32
+  - linux_arm
+  - linux_aarch64
+  - linux_aarch64_musl
+  - macOS
+  - macOS_arm64
+  - win_64
+  - win_32
+  - win_arm64
+  - ppc64le
+  - s390x
+  steps:
+    - template: publish.yml
 
 trigger:
   branches:
-    include:
-      - main
+   include:
+   - main
   tags:
     include:
-      - v*
+    - v*

--- a/build/main.yml
+++ b/build/main.yml
@@ -1,113 +1,113 @@
 jobs:
-- job: linux_64
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: x86_64-unknown-linux-musl
-- job: linux_32
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: i686-unknown-linux-musl
-- job: linux_arm
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: arm-unknown-linux-gnueabihf
-- job: linux_aarch64
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: aarch64-unknown-linux-gnu
-- job: linux_aarch64_musl
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: aarch64-unknown-linux-musl
-- job: macOS
-  pool:
-    vmImage: macOS-latest
-  steps:
-    - template: linux.yml
-      parameters:
-        target: x86_64-apple-darwin
-- job: macOS_arm64
-  pool:
-    vmImage: macOS-latest
-  steps:
-    - template: linux.yml
-      parameters:
-        target: aarch64-apple-darwin
-        rust_version: nightly
-- job: win_64
-  pool:
-    vmImage: windows-2022
-  steps:
-    - template: windows.yml
-      parameters:
-        target: x86_64-pc-windows-msvc
-- job: win_32
-  pool:
-    vmImage: windows-2022
-  steps:
-    - template: windows.yml
-      parameters:
-        target: i686-pc-windows-msvc
-- job: win_arm64
-  pool:
-    vmImage: windows-2022
-  steps:
-    - template: windows.yml
-      parameters:
-        target: aarch64-pc-windows-msvc
-- job: ppc64le
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: powerpc64le-unknown-linux-gnu
-- job: s390x
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-    - template: linux.yml
-      parameters:
-        target: s390x-unknown-linux-gnu
-- job: publish
-  pool:
-    vmImage: 'ubuntu-latest'
-  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
-  dependsOn:
-  - linux_64
-  - linux_32
-  - linux_arm
-  - linux_aarch64
-  - linux_aarch64_musl
-  - macOS
-  - macOS_arm64
-  - win_64
-  - win_32
-  - win_arm64
-  - ppc64le
-  - s390x
-  steps:
-    - template: publish.yml
+  - job: linux_64
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: x86_64-unknown-linux-musl
+  - job: linux_32
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: i686-unknown-linux-musl
+  - job: linux_arm
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: arm-unknown-linux-musleabihf
+  - job: linux_aarch64
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: aarch64-unknown-linux-gnu
+  - job: linux_aarch64_musl
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: aarch64-unknown-linux-musl
+  - job: macOS
+    pool:
+      vmImage: macOS-latest
+    steps:
+      - template: linux.yml
+        parameters:
+          target: x86_64-apple-darwin
+  - job: macOS_arm64
+    pool:
+      vmImage: macOS-latest
+    steps:
+      - template: linux.yml
+        parameters:
+          target: aarch64-apple-darwin
+          rust_version: nightly
+  - job: win_64
+    pool:
+      vmImage: windows-2022
+    steps:
+      - template: windows.yml
+        parameters:
+          target: x86_64-pc-windows-msvc
+  - job: win_32
+    pool:
+      vmImage: windows-2022
+    steps:
+      - template: windows.yml
+        parameters:
+          target: i686-pc-windows-msvc
+  - job: win_arm64
+    pool:
+      vmImage: windows-2022
+    steps:
+      - template: windows.yml
+        parameters:
+          target: aarch64-pc-windows-msvc
+  - job: ppc64le
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: powerpc64le-unknown-linux-gnu
+  - job: s390x
+    pool:
+      vmImage: "ubuntu-latest"
+    steps:
+      - template: linux.yml
+        parameters:
+          target: s390x-unknown-linux-gnu
+  - job: publish
+    pool:
+      vmImage: "ubuntu-latest"
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    dependsOn:
+      - linux_64
+      - linux_32
+      - linux_arm
+      - linux_aarch64
+      - linux_aarch64_musl
+      - macOS
+      - macOS_arm64
+      - win_64
+      - win_32
+      - win_arm64
+      - ppc64le
+      - s390x
+    steps:
+      - template: publish.yml
 
 trigger:
   branches:
-   include:
-   - main
+    include:
+      - main
   tags:
     include:
-    - v*
+      - v*

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -52,7 +52,7 @@ architecture() {
 
 gcc_prefix() {
     case "$(architecture)" in
-        armhf)
+        armhf-musl)
             echo arm-linux-musleabihf-
             ;;
         aarch64)

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -88,9 +88,9 @@ is_x86_64() {
     esac
 }
 
-is_arm() {
+is_arm_musl() {
     case "$(architecture)" in
-        armhf) return 0 ;;
+        armhf-musl) return 0 ;;
         *)     return 1 ;;
     esac
 }

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -52,6 +52,9 @@ architecture() {
 
 gcc_prefix() {
     case "$(architecture)" in
+        armhf)
+            echo arm-linux-musleabihf-
+            ;;
         aarch64)
             echo aarch64-linux-gnu-
             ;;

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -53,7 +53,7 @@ architecture() {
 gcc_prefix() {
     case "$(architecture)" in
         armhf-musl)
-            echo arm-linux-musleabihf-
+            echo arm-linux-gnueabihf-
             ;;
         aarch64)
             echo aarch64-linux-gnu-

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -148,7 +148,7 @@ is_osx() {
 }
 
 builder() {
-    if is_musl && is_aarch64_musl; then
+    if is_musl; then
         cargo install cross --version 0.2.1
         echo "cross"
     else

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -53,7 +53,7 @@ architecture() {
 gcc_prefix() {
     case "$(architecture)" in
         armhf-musl)
-            echo arm-linux-gnueabihf-
+            echo arm-linux-musleabihf-
             ;;
         aarch64)
             echo aarch64-linux-gnu-

--- a/build/utils.sh
+++ b/build/utils.sh
@@ -26,8 +26,8 @@ architecture() {
         i686-*|i586-*|i386-*)
             echo i386
             ;;
-        arm*-unknown-linux-gnueabihf)
-            echo armhf
+        arm*-unknown-linux-musleabihf)
+            echo armhf-musl
             ;;
         aarch64-unknown-linux-gnu)
             echo aarch64
@@ -52,9 +52,6 @@ architecture() {
 
 gcc_prefix() {
     case "$(architecture)" in
-        armhf)
-            echo arm-linux-gnueabihf-
-            ;;
         aarch64)
             echo aarch64-linux-gnu-
             ;;


### PR DESCRIPTION
Fixes #24 

It seems that rust supports a musl version of `arm-unknown-linux-gnueabihf`, so use that one. Since we are cross-compiling, we don't need the host tool support.

https://doc.rust-lang.org/nightly/rustc/platform-support.html