### PR TITLE
chore: change Rust version to stable

### DIFF
--- a/build/linux.yml
+++ b/build/linux.yml
@@ -1,6 +1,6 @@
 parameters:
   target: ''
-  rust_version: '1.76.0'
+  rust_version: 'stable'
   repo: ''
   tag: ''
 


### PR DESCRIPTION
With this PR, we always use the latest stable Rust when building ripgrep for Linux.

Verification build: https://dev.azure.com/vscode/ripgrep-prebuilt/_build/results?buildId=118999&view=results