### PR TITLE
chore: disable APIScan

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -91,13 +91,13 @@ extends:
             - template: build/windows.yml@self
               parameters:
                 target: x86_64-pc-windows-msvc
-        - job: win_64_apiscan
-          pool:
-            name: 1es-oss-windows-2022-x64
-          steps:
-            - template: build/windows-apiscan.yml@self
-              parameters:
-                target: x86_64-pc-windows-msvc
+        # - job: win_64_apiscan
+        #   pool:
+        #     name: 1es-oss-windows-2022-x64
+        #   steps:
+        #     - template: build/windows-apiscan.yml@self
+        #       parameters:
+        #         target: x86_64-pc-windows-msvc
         - job: win_32
           pool:
             name: 1es-oss-windows-2022-x64


### PR DESCRIPTION
Disables APIScan for ripgrep-prebuilt considering that we have scanned the binary and that the pipeline's ADO org has not been onboarded onto the latest Service Connection functionality, meaning we are unable to use the newest APIScan task anyway.