### PR TITLE
chore: use tag name in publish stage

### DIFF
--- a/build/main.yml
+++ b/build/main.yml
@@ -126,6 +126,7 @@ extends:
 
       - stage: Publish
         dependsOn: Build
+        condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')
         jobs:
         - job: publish
           pool:
@@ -136,40 +137,40 @@ extends:
             isProduction: true
             inputs:
             - input: pipelineArtifact
-              artifactName: ripgrep--aarch64-apple-darwin.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--aarch64-apple-darwin.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-aarch64-apple-darwin.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-aarch64-apple-darwin.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--aarch64-pc-windows-msvc.zip
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--aarch64-pc-windows-msvc.zip
+              artifactName: ripgrep-$(Build.SourceBranchName)-aarch64-pc-windows-msvc.zip
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-aarch64-pc-windows-msvc.zip
             - input: pipelineArtifact
-              artifactName: ripgrep--aarch64-unknown-linux-gnu.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--aarch64-unknown-linux-gnu.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-aarch64-unknown-linux-gnu.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-aarch64-unknown-linux-gnu.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--aarch64-unknown-linux-musl.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--aarch64-unknown-linux-musl.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-aarch64-unknown-linux-musl.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-aarch64-unknown-linux-musl.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--arm-unknown-linux-gnueabihf.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--arm-unknown-linux-gnueabihf.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-arm-unknown-linux-gnueabihf.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-arm-unknown-linux-gnueabihf.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--i686-pc-windows-msvc.zip
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--i686-pc-windows-msvc.zip
+              artifactName: ripgrep-$(Build.SourceBranchName)-i686-pc-windows-msvc.zip
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-i686-pc-windows-msvc.zip
             - input: pipelineArtifact
-              artifactName: ripgrep--i686-unknown-linux-musl.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--i686-unknown-linux-musl.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-i686-unknown-linux-musl.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-i686-unknown-linux-musl.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--powerpc64le-unknown-linux-gnu.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--powerpc64le-unknown-linux-gnu.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-powerpc64le-unknown-linux-gnu.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-powerpc64le-unknown-linux-gnu.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--s390x-unknown-linux-gnu.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--s390x-unknown-linux-gnu.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-s390x-unknown-linux-gnu.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-s390x-unknown-linux-gnu.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--x86_64-apple-darwin.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--x86_64-apple-darwin.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-x86_64-apple-darwin.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-x86_64-apple-darwin.tar.gz
             - input: pipelineArtifact
-              artifactName: ripgrep--x86_64-pc-windows-msvc.zip
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--x86_64-pc-windows-msvc.zip
+              artifactName: ripgrep-$(Build.SourceBranchName)-x86_64-pc-windows-msvc.zip
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-x86_64-pc-windows-msvc.zip
             - input: pipelineArtifact
-              artifactName: ripgrep--x86_64-unknown-linux-musl.tar.gz
-              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep--x86_64-unknown-linux-musl.tar.gz
+              artifactName: ripgrep-$(Build.SourceBranchName)-x86_64-unknown-linux-musl.tar.gz
+              targetPath: $(Build.ArtifactStagingDirectory)/ripgrep-$(Build.SourceBranchName)-x86_64-unknown-linux-musl.tar.gz
           steps:
             - template: build/publish.yml@self

--- a/build/publish.yml
+++ b/build/publish.yml
@@ -7,7 +7,6 @@ steps:
     target: '$(Build.SourceVersion)'
     tagSource: 'userSpecifiedTag'
     tag: '$(Build.SourceBranchName)'
-    assets: '$(Build.ArtifactStagingDirectory)/**/ripgrep--*.*'
+    assets: '$(Build.ArtifactStagingDirectory)/**/ripgrep-*.*'
     assetUploadMode: 'replace'
     addChangeLog: true
-  condition: startsWith(variables['Build.SourceBranch'], 'refs/tags/v')


### PR DESCRIPTION
This PR changes the publish pipeline to include the tag name while retrieving the artifacts. It also moves the condition from the job to the stage so that the Publish stage does not show up on non-publishing builds.