### PR TITLE
ci: add 16k and 64k qemu jobs for aarch64

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -26,7 +26,7 @@ main() {
     elif is_s390x || is_riscv64; then
         "$CARGO" build --release --target=$TARGET
     elif is_aarch64_musl; then
-        "$CARGO" build --target "$TARGET" --release --features 'pcre2'
+        PCRE2_SYS_STATIC=1 "$CARGO" build --target "$TARGET" --release --features 'pcre2'
     else
         # Technically, MUSL builds will force PCRE2 to get statically compiled,
         # but we also want PCRE2 statically build for macOS binaries.

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -43,13 +43,16 @@ steps:
       CURRENTDIR: $(Build.SourcesDirectory)
       DOCKERCMD: >
         echo $(pwd) &&
-        apk add --no-cache musl-dev lld file &&
+        apk add --no-cache musl-dev lld file qemu-user &&
+        if [ "${USE_QEMU}" = "true" ]; then
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-aarch64 -p ${QEMU_PAGE_SIZE}";
+        fi &&
         ./build/install.sh &&
         cd ripgrep && ../build/build.sh
     inputs:
       targetType: 'inline'
       script: |
-          docker run --pull always --privileged --rm --volume "${CURRENTDIR}":/app --workdir /app --env RUST_VERSION="${{ parameters.rust_version }}" --env USE_MARINER="${{ parameters.use_mariner }}" --env TARGET="${{ parameters.target }}" --env OUT_DIR="$(Build.ArtifactStagingDirectory)" mcr.microsoft.com/devcontainers/base:alpine-3.19 /bin/sh -c "${DOCKERCMD}"
+          docker run --pull always --privileged --rm --volume "${CURRENTDIR}":/app --workdir /app --env RUST_VERSION="${{ parameters.rust_version }}" --env USE_MARINER="${{ parameters.use_mariner }}" --env TARGET="${{ parameters.target }}" --env OUT_DIR="$(Build.ArtifactStagingDirectory)" --env USE_QEMU="${{ parameters.use_qemu }}" --env QEMU_PAGE_SIZE="${{ parameters.qemu_page_size }}" mcr.microsoft.com/devcontainers/base:alpine-3.19 /bin/sh -c "${DOCKERCMD}"
 - ${{ else }}:
   - script: build/install.sh
     displayName: Install Rust
@@ -57,20 +60,11 @@ steps:
       RUST_VERSION: ${{ parameters.rust_version }}
       TARGET: ${{ parameters.target }}
 
-  - ${{ if eq(parameters.use_qemu, true) }}:
-    - script: |
-        set -ex
-        sudo apt-get update
-        sudo apt-get install -y qemu-user
-      displayName: Install QEMU user-mode emulation
-
   - script: ../build/build.sh
     displayName: Build
     workingDirectory: ripgrep
     env:
       TARGET: ${{ parameters.target }}
-      ${{ if eq(parameters.use_qemu, true) }}:
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER: qemu-aarch64 -p ${{ parameters.qemu_page_size }}
 
 - ${{ if eq(parameters.target, 'aarch64-unknown-linux-musl') }}:
   - script: |

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -4,6 +4,9 @@ parameters:
   repo: ''
   tag: ''
   use_mariner: false
+  use_qemu: false
+  qemu_page_size: '16384'
+  publish_artifact: true
 
 steps:
 - task: UseNode@1
@@ -54,11 +57,20 @@ steps:
       RUST_VERSION: ${{ parameters.rust_version }}
       TARGET: ${{ parameters.target }}
 
+  - ${{ if eq(parameters.use_qemu, true) }}:
+    - script: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y qemu-user
+      displayName: Install QEMU user-mode emulation
+
   - script: ../build/build.sh
     displayName: Build
     workingDirectory: ripgrep
     env:
       TARGET: ${{ parameters.target }}
+      ${{ if eq(parameters.use_qemu, true) }}:
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER: qemu-aarch64 -p ${{ parameters.qemu_page_size }}
 
 - ${{ if eq(parameters.target, 'aarch64-unknown-linux-musl') }}:
   - script: |
@@ -70,20 +82,21 @@ steps:
     displayName: Verify jemalloc LG_PAGE (aarch64 musl)
     workingDirectory: ripgrep
 
-- script: ../build/package.sh
-  displayName: Package
-  workingDirectory: ripgrep
-  env:
-    TARGET: ${{ parameters.target }}
-    OUT_DIR: $(Build.ArtifactStagingDirectory)
-  condition: succeeded()
+- ${{ if eq(parameters.publish_artifact, true) }}:
+  - script: ../build/package.sh
+    displayName: Package
+    workingDirectory: ripgrep
+    env:
+      TARGET: ${{ parameters.target }}
+      OUT_DIR: $(Build.ArtifactStagingDirectory)
+    condition: succeeded()
 
-- task: 1ES.PublishPipelineArtifact@1
-  displayName: 'Publish Pipeline Artifact'
-  inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)
-    artifactName: $(Name)
-    sbomBuildDropPath: $(Build.ArtifactStagingDirectory)
-    sbomBuildComponentPath: $(Build.SourcesDirectory)/ripgrep
-    sbomPackageName: "ripgrep-prebuilt (${{ parameters.target }})"
-  condition: succeeded()
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: 'Publish Pipeline Artifact'
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)
+      artifactName: $(Name)
+      sbomBuildDropPath: $(Build.ArtifactStagingDirectory)
+      sbomBuildComponentPath: $(Build.SourcesDirectory)/ripgrep
+      sbomPackageName: "ripgrep-prebuilt (${{ parameters.target }})"
+    condition: succeeded()

--- a/build/linux.yml
+++ b/build/linux.yml
@@ -43,9 +43,15 @@ steps:
       CURRENTDIR: $(Build.SourcesDirectory)
       DOCKERCMD: >
         echo $(pwd) &&
-        apk add --no-cache musl-dev lld file qemu-user &&
+        apk add --no-cache musl-dev lld file &&
         if [ "${USE_QEMU}" = "true" ]; then
-          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="qemu-aarch64 -p ${QEMU_PAGE_SIZE}";
+          apk add --no-cache qemu-user || apk add --no-cache qemu-user-static || apk add --no-cache qemu-aarch64;
+          QEMU_BIN="$(command -v qemu-aarch64 || true)";
+          if [ -z "${QEMU_BIN}" ]; then
+            QEMU_BIN="$(command -v qemu-aarch64-static || true)";
+          fi;
+          test -n "${QEMU_BIN}";
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER="${QEMU_BIN} -p ${QEMU_PAGE_SIZE}";
         fi &&
         ./build/install.sh &&
         cd ripgrep && ../build/build.sh

--- a/build/main.yml
+++ b/build/main.yml
@@ -68,6 +68,30 @@ extends:
               parameters:
                 target: aarch64-unknown-linux-musl
                 use_mariner: true
+        - job: linux_aarch64_musl_qemu_16k
+          pool:
+            name: 1es-azure-linux-3-arm64
+            os: linux
+            hostArchitecture: Arm64
+          steps:
+            - template: build/linux.yml@self
+              parameters:
+                target: aarch64-unknown-linux-musl
+                use_qemu: true
+                qemu_page_size: '16384'
+                publish_artifact: false
+        - job: linux_aarch64_musl_qemu_64k
+          pool:
+            name: 1es-azure-linux-3-arm64
+            os: linux
+            hostArchitecture: Arm64
+          steps:
+            - template: build/linux.yml@self
+              parameters:
+                target: aarch64-unknown-linux-musl
+                use_qemu: true
+                qemu_page_size: '65536'
+                publish_artifact: false
         - job: macOS
           pool:
             name: Azure Pipelines

--- a/build/main.yml
+++ b/build/main.yml
@@ -77,6 +77,7 @@ extends:
             - template: build/linux.yml@self
               parameters:
                 target: aarch64-unknown-linux-musl
+                use_mariner: true
                 use_qemu: true
                 qemu_page_size: '16384'
                 publish_artifact: false
@@ -89,6 +90,7 @@ extends:
             - template: build/linux.yml@self
               parameters:
                 target: aarch64-unknown-linux-musl
+                use_mariner: true
                 use_qemu: true
                 qemu_page_size: '65536'
                 publish_artifact: false


### PR DESCRIPTION
Jemalloc doesn't have runtime detection for page size it is compile time and we currently build with 64k to support 4k, 16k and 64k linux aarch64 distros, there is definitely going to be some memory fragmentation at runtime for 4k and 16k but do we get other undefined behaviors/crashes in this configuration ? I am not sure, but running official tests gives some sort of confidence.